### PR TITLE
Corrected English grammar of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # QGISBR Sharing Resources
 
-This repository contains styles, scripts, models and other QGIS 
-resources that can be shared with the QGIS Resources Sharing.
+This repository contains styles, scripts, models, and other QGIS 
+resources that you can share through the [QGIS Resources Sharing](https://plugins.qgis.org/plugins/qgis_resource_sharing/).
 
 ## Collections
 


### PR DESCRIPTION
I corrected the grammar of `README.md` and added a hyperlink to QGIS Resources Sharing of QGIS Python Plugins Repository (https://plugins.qgis.org/plugins/qgis_resource_sharing/). In this way, my main purpose is both to enhance this repository interaction (since we can link to other important pages) and remove its English mistakes.