### PR TITLE
Alterando dados do metadata.ini

### DIFF
--- a/metadata.ini
+++ b/metadata.ini
@@ -47,4 +47,4 @@ qgis_minimum_version=3.10
 qgis_maximum_version=3.98
 license=GNU GPL 3
 license_file=LICENSE.md
-preview=preview/cronoestratigrafico.jpg, preview/dominios.jpg, preview/unidades_litoestratigraficas.jpg
+preview=preview/cronoestratigrafico.png, preview/dominios.png, preview/unidades_litoestratigraficas.png, preview/geologia_simplificada.png, preview/un_litoestratigraficas_escala_1-100_000.png, preview/unidades_geologicas_ambientais.png


### PR DESCRIPTION
As imagens de preview das litologias do CPRM, no plugin Resource Sharing do QGIS, não estavam carregando. O problema se deu pela incompatibilidade descrita no arquivo **metadata.ini.** As extensões foram alteradas de `jpg` para `png`. 